### PR TITLE
fix(plugin): properly handle late added files

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,15 @@ function tsify(b, opts) {
 	var tsifier = new Tsifier(opts);
 	tsifier.on('error', function (error) { b.emit('error', error); });
 
+	var files = [];
+
+	b.on('file', function(f) {
+		files.push(f);
+	});
+
 	b.on('bundle', function () {
 		tsifier.clearCompilationCache();
-		tsifier.compileAndCacheFiles((b._entries || b._options.entries).filter(Tsifier.isTypescript));
+		tsifier.compileAndCacheFiles((b._entries || b._options.entries || files).filter(Tsifier.isTypescript));
 	});
 
 	b.transform(tsifier.transform.bind(tsifier));

--- a/test.js
+++ b/test.js
@@ -55,6 +55,26 @@ test('type error', function (t) {
 	});
 });
 
+test('late added entries', function(t) {
+	t.plan(8);
+
+	// test we properly handle late added entries
+	var expected = fs.readFileSync('./test/noArguments/expected.js').toString();
+
+	var errors = [];
+	browserify({ debug: true })
+		.plugin('./index.js')
+		.on('error', function (error) {
+			errors.push(error);
+		})
+		.add('./test/noArguments/x.ts')
+		.bundle()
+		.pipe(es.wait(function (err, actual) {
+			t.equal(errors.length, 0, 'Should have no compilation errors');
+			expectCompiledOutput(t, expected, actual.toString());
+		}));
+});
+
 function expectSuccess(t, main, expectedFile) {
 	var expected = fs.readFileSync(expectedFile).toString();
 	run(main, function (errors, actual) {


### PR DESCRIPTION
This commit adds proper handling for late added files supported from
browserify 5.x on.

It is backwards compatible with browserify 4.x and the existing 5.x
behavior (which supports options.entries) only).
