### PR TITLE
Update for Browserify 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "ansidiff": "^1.0.0",
-    "browserify": "^7.0.3",
+    "browserify": "^8.0.2",
     "event-stream": "^3.1.7",
     "fs-extra": "^0.13.0",
     "jshint": "^2.5.10",
@@ -41,6 +41,6 @@
     "watchify": "^2.2.1"
   },
   "peerDependencies": {
-    "browserify": "6.x || 7.x"
+    "browserify": "6.x || 7.x || 8.x"
   }
 }


### PR DESCRIPTION
Seemed like you were tagging and then updating the changelog so I didn't include what I assume will be a 0.7.1 line
