### PR TITLE
Fix for TypeScript breaking change relating to file names.

### DIFF
--- a/lib/Host.js
+++ b/lib/Host.js
@@ -1,7 +1,7 @@
 var events = require('events');
-var fs     = require('fs');
-var log    = require('debuglog')(require('../package').name);
-var os     = require('os');
+var fs	 = require('fs');
+var log	= require('debuglog')(require('../package').name);
+var os	 = require('os');
 var path   = require('path');
 var util   = require('util');
 
@@ -28,9 +28,9 @@ module.exports = function (ts) {
 		log('Resetting (version %d)', this.version);
 	};
 
-    Host.prototype._normalizedRelative = function(filename) {
-        return ts.normalizePath(path.relative(this.currentDirectory, path.resolve(filename)));
-    };
+	Host.prototype._normalizedRelative = function(filename) {
+		return ts.normalizePath(path.relative(this.currentDirectory, path.resolve(filename)));
+	};
 
 	Host.prototype._addFile = function (filename, root) {
 		var normalized = this._normalizedRelative(filename);
@@ -89,7 +89,7 @@ module.exports = function (ts) {
 	};
 
 	Host.prototype.writeFile = function (filename, data) {
-        this.output[this._normalizedRelative(filename)] = data;
+		this.output[this._normalizedRelative(filename)] = data;
 	};
 
 	Host.prototype.getCurrentDirectory = function () {

--- a/lib/Host.js
+++ b/lib/Host.js
@@ -28,8 +28,12 @@ module.exports = function (ts) {
 		log('Resetting (version %d)', this.version);
 	};
 
+    Host.prototype._normalizedRelative = function(filename) {
+        return ts.normalizePath(path.relative(this.currentDirectory, path.resolve(filename)));
+    };
+
 	Host.prototype._addFile = function (filename, root) {
-		var normalized = ts.normalizePath(filename);
+		var normalized = this._normalizedRelative(filename);
 
 		var text;
 		try {
@@ -67,7 +71,7 @@ module.exports = function (ts) {
 	}
 
 	Host.prototype.getSourceFile = function (filename) {
-		var normalized = ts.normalizePath(filename);
+		var normalized = this._normalizedRelative(filename);
 
 		if (this.files[normalized])
 			return this.files[normalized].ts;
@@ -85,7 +89,7 @@ module.exports = function (ts) {
 	};
 
 	Host.prototype.writeFile = function (filename, data) {
-		this.output[filename] = data;
+        this.output[this._normalizedRelative(filename)] = data;
 	};
 
 	Host.prototype.getCurrentDirectory = function () {
@@ -93,7 +97,7 @@ module.exports = function (ts) {
 	};
 
 	Host.prototype.getCanonicalFileName = function (filename) {
-		return ts.normalizePath(filename);
+		return this._normalizedRelative(filename);
 	};
 
 	Host.prototype.useCaseSensitiveFileNames = function () {
@@ -110,7 +114,7 @@ module.exports = function (ts) {
 	};
 
 	Host.prototype.readFile = function (filename) {
-		var normalized = ts.normalizePath(filename);
+		var normalized = this._normalizedRelative(filename);
 		return ts.sys.readFile(normalized);
 	};
 

--- a/lib/Host.js
+++ b/lib/Host.js
@@ -1,7 +1,7 @@
 var events = require('events');
-var fs	 = require('fs');
-var log	= require('debuglog')(require('../package').name);
-var os	 = require('os');
+var fs     = require('fs');
+var log    = require('debuglog')(require('../package').name);
+var os     = require('os');
 var path   = require('path');
 var util   = require('util');
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debuglog": "^1.0.1",
     "lodash": "^3.8.0",
     "through2": "^2.0.0",
-    "typescript": "~1.7.3"
+    "typescript": "~1.8.2"
   },
   "devDependencies": {
     "browserify": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debuglog": "^1.0.1",
     "lodash": "^3.8.0",
     "through2": "^2.0.0",
-    "typescript": "~1.8.2"
+    "typescript": "~1.8.7"
   },
   "devDependencies": {
     "browserify": "^11.0.1",


### PR DESCRIPTION
Use of absolute paths as file keys in https://github.com/Microsoft/TypeScript/commit/b8a3564d284fb2344dcedcc603fcc23cd5a0f1f6 caused #110. This resolves the absolute path before normalization.