### PR TITLE
Replace backslashes in the current directory.

### DIFF
--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -11,7 +11,7 @@ var _       = require('lodash');
 module.exports = function (ts) {
 	var CompileError     = require('./CompileError')(ts);
 	var Host             = require('./Host')(ts);
-	var currentDirectory = fs.realpathSync(process.cwd());
+	var currentDirectory = fs.realpathSync(process.cwd()).replace(/\\/g, '/');
 
 	var parseJsonConfigFileContent = ts.parseJsonConfigFileContent || ts.parseConfigFile;
 


### PR DESCRIPTION
On Windows, backslashes in the current directory's path prevent the TypeScript `findConfigFile` function from finding `tsconfig.json` files that are located in a directory that is a parent of the current directory. It seems that TypeScript assumes paths will [use slashes as separators](https://github.com/Microsoft/TypeScript/blob/v1.8.9/src/compiler/core.ts#L598).