### PR TITLE
switch to hard-coded tsconfig.json string

### DIFF
--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -49,7 +49,7 @@ module.exports = function (ts) {
 	function parseOptions(opts) {
 		var configFile = ts.findConfigFile(currentDirectory, fileExists);
 		if (configFile) {
-			var configFileContents = require(path.join(currentDirectory, configFile));
+			var configFileContents = require(path.join(currentDirectory, 'tsconfig.json'));
 			opts = _.extend(configFileContents.compilerOptions, opts);
 		}
 


### PR DESCRIPTION
First of all, `tsify` is an awesome project, and is integrating nicely with my company's existing `browserify-grunt` and `karma` build processes. Pretty darn sweet!

But I noticed there's a problem on the bleeding edge - TypeScript is changing how `ts.findConfigFile()` works to solve this issue: https://github.com/Microsoft/TypeScript/issues/2965, and now in `typescript@next` when the function succeeds it returns the path to `tsconfig.json`, rather than just the string `tsconfig.json`.

So, when I specify `"typescript": "^1.9.0-dev.20160402"` in my package.json, and then pass `tsify` `{ typescript: require('typescript') }`, I get this fun error:
```
Cannot find module '/path/to/currentDirectory/path/to/currentDirectory/tsconfig.json'
```
So, it seems like the solution is, if `ts.findConfigFile` returns something (meaning `ts` found the config file), then hard-code to `'tsconfig.json'`, which is all the current (1.8) version of ts does here: https://github.com/Microsoft/TypeScript/pull/7702/files#diff-08a3cc4f1f9a51dbb468c2810f5229d3L18

The tests in `test-main` all pass, this certainly fixes my problem in TypeScript 1.9, and it also doesn't complain when I switch back to TypeScript 1.8.7. So, I'm pretty sure this won't break anything :-D, and it should help `tsify` get ready for TypeScript 2.0.