### PR TITLE
Documented square bracket usage in example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ $ browserify main.ts -p [ tsify --noImplicitAny ] > bundle.js
 
 Note that when using the Browserify CLI, compilation will always halt on the first error encountered, unlike the regular TypeScript CLI.  This behavior can be overridden in the API, as shown in the API example.
 
+Also note that square brackets `[ ]` in above example are required if you want to pass parameters to TypeScript compiler, they don't denote optional part of the command.
+
 # Installation
 
 Just plain ol' [npm](https://npmjs.org/) installation:


### PR DESCRIPTION
# Changed README.md so that it clearly says that square brackets are required in command and does not denote optional argument
Not sure if it is only me but I had hard time figuring out how to pass `--experimentalDecorators` to TypeScript compiler when trying to compile Angular2 source code using command line. 

This was due to misunderstanding of documentation and example command line usage. Example command `browserify main.ts -p [ tsify --noImplicitAny ] > bundle.js` has square brackets around tsify plugin which lead me to think that it means optional part of the command as this is the usual syntax. See for example: http://stackoverflow.com/questions/8716047/is-there-a-specification-for-a-man-pages-synopsis-section

For this reason I initially called `browserify main.ts -p tsify > bundle.js` which works but then I needed to pass experimentalDecorators option to compiler and tried it like this: `browserify main.ts -p tsify --experimentalDecorators > bundle.js`. This doesn't work however and I still got warning about missing flag. 

So for this reason I thought that it would be good to mention something about square bracket usage in the readme file to help future users.  