### PR TITLE
Replaced backslashes and use the tsconfig directory as the root

### DIFF
--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -54,11 +54,12 @@ module.exports = function (ts) {
 		if (fileExists(opts.project)) {
 			configFile = opts.project;
 		} else {
-			configFile = ts.findConfigFile(
-				opts.project || bopts.basedir || currentDirectory,
-				fileExists);
+			var directory = opts.project || bopts.basedir || currentDirectory;
+			directory = directory.replace(/\\/g, '/');
+			configFile = ts.findConfigFile(directory, fileExists);
 		}
 
+		var files;
 		if (configFile) {
 			var configFileContents = require(path.resolve(currentDirectory, configFile));
 			opts = extend(configFileContents.compilerOptions || {}, opts);

--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -91,7 +91,7 @@ module.exports = function (ts) {
 		// The output directory needs to be distinct from the input directory to prevent the TS
 		// compiler from thinking that it might accidentally overwrite source files, which would
 		// prevent it from outputting e.g. the results of transpiling ES6 JS files with --allowJs.
-		parsed.options.rootDir = currentDirectory;
+		parsed.options.rootDir = path.resolve(path.dirname(configFile)).replace(/\\/g, '/');
 		parsed.options.outDir = '__tsify__';
 
 		if (configFile) {
@@ -271,7 +271,10 @@ module.exports = function (ts) {
 		var normalized = ts.normalizePath(inputFile);
 
 		var outputExtension = (self.opts.jsx === ts.JsxEmit.Preserve && isTsx(inputFile)) ? '.jsx' : '.js';
-		var outputFile = '__tsify__/' + replaceFileExtension(normalized, outputExtension);
+		var outputFile = '__tsify__/' + path.relative(
+			self.opts.rootDir,
+			path.resolve(replaceFileExtension(normalized, outputExtension))
+		).replace(/\\/g, '/');
 		var output = self.host.output[outputFile];
 
 		if (!output) {


### PR DESCRIPTION
With Windows, it seems that Browserify's `basedir` contains backslashes. So, for the TypeScript `findConfigFile` function to work correctly, they need to be replaced. (Also, the `files` variable used in the `parseOptions` function was not defined.)

I spent some time looking into a problem that was introduced with [this commit](https://github.com/TypeStrong/tsify/commit/57b9b42c23bb05324d85f520aaf84c8f397d3377) - after which I was unable to use tsify to build my projects.

I often have multiple projects in a single repo, with a common `tsconfig.json` file in the repo's root directory and the projects themselves in sub-directories. Consequently, when in a project directory, the `tsconfig.json` file is one level higher than would ordinarily be expected. (For numerous reasons, I do not want to have per-project `tsconfig.json` files and typings, etc.) Until the above mentioned commit was made, this had not been a problem.

Rather then set the `rootDir` to the current directory (i.e. the project directory), the commit in this PR sets it to the directory containing the `tsconfig.json` file. And this is taken into account when the `__tsify__`-based path is constructed in the `getCompiledFile` function.

With these changes, I can now use the latest tsify to build my projects. The change should make no difference to projects that have a `tsconfig.json` in the usual place and it's possible that the change will also address the bug(s) in issues #136 and #137.