### PR TITLE
Disregard compilerOptions.noEmit

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For use on the command line, use the flag `npm install -g`.
 tsify will automatically read options from `tsconfig.json`.  However, some options from this file will be ignored:
 
 * `compilerOptions.declaration` - See [tsify#15](https://github.com/TypeStrong/tsify/issues/15)
-* `compilerOptions.out` and `compilerOptions.outDir` - Use Browserify's file output options instead.  These options are overridden because **tsify** writes its intermediate JavaScript output to an internal memory store instead of to the filesystem.
+* `compilerOptions.out`, `compilerOptions.outDir`, and `compilerOptions.noEmit` - Use Browserify's file output options instead.  These options are overridden because **tsify** writes its intermediate JavaScript output to an internal memory store instead of to the filesystem.
 * `files` - Use Browserify's file input options instead.  This is necessary because Browserify needs to know which file(s) are the entry points to your program.
 
 ### Watchify?

--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -82,10 +82,11 @@ module.exports = function (ts) {
 		// Default to CommonJS module mode
 		parsed.options.module = parsed.options.module || ts.ModuleKind.CommonJS;
 
-		// Blacklist --out/--outFile; these should definitely not be set, since we are doing
+		// Blacklist --out/--outFile/--noEmit; these should definitely not be set, since we are doing
 		// concatenation with Browserify instead
 		delete parsed.options.out;
 		delete parsed.options.outFile;
+		delete parsed.options.noEmit;
 
 		// Set rootDir and outDir so we know exactly where the TS compiler will be trying to
 		// write files; the filenames will end up being the keys into our in-memory store.


### PR DESCRIPTION
This PR adds `compilerOptions.noEmit` to the blacklist of `tsconfig.json` options, as it creates an empty bundle. I think it's reasonable to assume that if someone is using `tsify`, they clearly intend to emit *something*. In my case, I add `noEmit` to my `tsconfig.json` to dry-run compile the application directly with `tsc`.