### PR TITLE
Replace backslashes.

### DIFF
--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -55,9 +55,9 @@ module.exports = function (ts) {
 		if (fileExists(opts.project)) {
 			configFile = opts.project;
 		} else {
-			configFile = ts.findConfigFile(
-				opts.project || bopts.basedir || currentDirectory,
-				fileExists);
+			var directory = opts.project || bopts.basedir || currentDirectory;
+			directory = directory.replace(/\\/g, '/');
+			configFile = ts.findConfigFile(directory, fileExists);
 		}
 
 		var config;


### PR DESCRIPTION
On Windows, the Browserify `basedir` contains backslashes and they need to be replaced if `findConfigFile` is to work correctly.