### PR TITLE
Used normalizeSlashes instead of regexp replacements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var fs      = require('fs');
 var through = require('through2');
 var path    = require('path');

--- a/lib/CompileError.js
+++ b/lib/CompileError.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var os = require('os');
 
 module.exports = function (ts) {

--- a/lib/Host.js
+++ b/lib/Host.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var commondir = require('commondir');
 var events    = require('events');
 var fs        = require('fs');

--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -14,7 +14,7 @@ var util     = require('util');
 module.exports = function (ts) {
 	var CompileError     = require('./CompileError')(ts);
 	var Host             = require('./Host')(ts);
-	var currentDirectory = fs.realpathSync(process.cwd()).replace(/\\/g, '/');
+	var currentDirectory = ts.normalizeSlashes(fs.realpathSync(process.cwd()));
 
 	var parseJsonConfigFileContent = ts.parseJsonConfigFileContent || ts.parseConfigFile;
 
@@ -39,8 +39,7 @@ module.exports = function (ts) {
 	}
 
 	function getRelativeFilename(file) {
-		return './' + path.relative(currentDirectory, file)
-			.replace(/\\/g, '/');
+		return './' + ts.normalizeSlashes(path.relative(currentDirectory, file));
 	}
 
 	function fileExists(file) {
@@ -57,9 +56,10 @@ module.exports = function (ts) {
 		if (fileExists(opts.project)) {
 			configFile = opts.project;
 		} else {
-			var directory = opts.project || bopts.basedir || currentDirectory;
-			directory = directory.replace(/\\/g, '/');
-			configFile = ts.findConfigFile(directory, fileExists);
+			configFile = ts.findConfigFile(
+				ts.normalizeSlashes(opts.project || bopts.basedir || currentDirectory),
+				fileExists
+			);
 		}
 
 		var config;
@@ -273,10 +273,10 @@ module.exports = function (ts) {
 		var rootDir = self.host._rootDir();
 
 		var outputExtension = (self.opts.jsx === ts.JsxEmit.Preserve && isTsx(inputFile)) ? '.jsx' : '.js';
-		var outputFile = '__tsify__/' + path.relative(
+		var outputFile = '__tsify__/' + ts.normalizeSlashes(path.relative(
 			rootDir,
 			path.resolve(replaceFileExtension(normalized, outputExtension))
-		).replace(/\\/g, '/');
+		));
 		var output = self.host.output[outputFile];
 
 		if (!output) {
@@ -299,7 +299,7 @@ module.exports = function (ts) {
 	Tsifier.prototype.setFullSourcePathInSourcemap = function (output, normalized) {
 		var self = this;
 		if (self.bopts.basedir) {
-			normalized = path.relative(self.bopts.basedir, normalized).replace(/\\/g, '/');
+			normalized = ts.normalizeSlashes(path.relative(self.bopts.basedir, normalized));
 		}
 
 		var sourcemap = convert.fromComment(output);

--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -14,7 +14,7 @@ var util     = require('util');
 module.exports = function (ts) {
 	var CompileError     = require('./CompileError')(ts);
 	var Host             = require('./Host')(ts);
-	var currentDirectory = ts.normalizeSlashes(fs.realpathSync(process.cwd()));
+	var currentDirectory = fs.realpathSync(process.cwd());
 
 	var parseJsonConfigFileContent = ts.parseJsonConfigFileContent || ts.parseConfigFile;
 

--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var convert  = require('convert-source-map');
 var events   = require('events');
 var extend   = require('util')._extend;

--- a/lib/time.js
+++ b/lib/time.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var log = require('util').debuglog(require('../package').name);
 
 function start() {

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var test = require('tape');
 
 var browserify = require('browserify');


### PR DESCRIPTION
I've replaced the regexp-based backslash normalization with calls to TypeScript's `normalizeSlashes` function. And I've removed what seems to be an unnecessary call - the `test-main` tests pass for me and my builds are fine.

I'm not sure whether or not all of the calls that are currently made to `normalizeSlashes` are required. I'm familiar with the implementation's general mechanism, but the specifics are a somewhat complicated. Unfortunately, the TypeScript 2.0.0 beta completely breaks my builds and the resultant bundles contain empty modules. I will submit another PR once I've gotten to the bottom of the problem. It's possible that at that point, I will have a better understanding of the specifics and can tidy up the normalization business a little more.

Also, I've added `use strict` statements, as their absence was hiding a missing variable declaration - that was fixed when I brought it to the [maintainer's attention](https://github.com/TypeStrong/tsify/pull/139#issuecomment-218845303) in a previous PR. Might as well let the runtime do that sort of thing.