### PR TITLE
Removed reset version from createSourceFile call

### DIFF
--- a/lib/Host.js
+++ b/lib/Host.js
@@ -46,21 +46,25 @@ module.exports = function (ts) {
 		}
 
 		var file;
-		if (this.previousFiles[normalized] &&
-			this.previousFiles[normalized].contents === text) {
-			file = this.previousFiles[normalized].ts;
-			log('Reused file %s (version %s)', normalized, file.version);
+		var previous = this.previousFiles[normalized];
+		var version;
+
+		if (previous && previous.contents === text) {
+			file = previous.ts;
+			version = previous.version;
+			log('Reused file %s (version %s)', normalized, version);
 		} else {
 			file = ts.createSourceFile(filename, text, this.languageVersion);
-			file.version = this.version;
-			log('New version of source file %s (version %s)', normalized, file.version);
+			version = this.version;
+			log('New version of source file %s (version %s)', normalized, version);
 		}
 
 		this.files[normalized] = {
 			filename: filename,
 			contents: text,
 			ts: file,
-			root: root
+			root: root,
+			version: version
 		};
 
 		this._emitFile(normalized);

--- a/lib/Host.js
+++ b/lib/Host.js
@@ -54,7 +54,7 @@ module.exports = function (ts) {
 			version = previous.version;
 			log('Reused file %s (version %s)', normalized, version);
 		} else {
-			file = ts.createSourceFile(filename, text, this.languageVersion);
+			file = ts.createSourceFile(filename, text, this.languageVersion, true);
 			version = this.version;
 			log('New version of source file %s (version %s)', normalized, version);
 		}

--- a/lib/Host.js
+++ b/lib/Host.js
@@ -51,7 +51,8 @@ module.exports = function (ts) {
 			file = this.previousFiles[normalized].ts;
 			log('Reused file %s (version %s)', normalized, file.version);
 		} else {
-			file = ts.createSourceFile(filename, text, this.languageVersion, String(this.version));
+			file = ts.createSourceFile(filename, text, this.languageVersion);
+			file.version = this.version;
 			log('New version of source file %s (version %s)', normalized, file.version);
 		}
 


### PR DESCRIPTION
The host maintains a [`version`](https://github.com/TypeStrong/tsify/blob/v1.0.1/lib/Host.js#L16) that tracks the number of times [`_reset`](https://github.com/TypeStrong/tsify/blob/v1.0.1/lib/Host.js#L27) has been called. The `version` is passed to [`createSourceFile`](https://github.com/TypeStrong/tsify/blob/v1.0.1/lib/Host.js#L52). However, it does not sensibly match the `createSourceFile` function's [API](https://github.com/Microsoft/TypeScript/blob/v1.8.10/src/compiler/parser.ts#L402-L408) and the returned object does not contain a `version`.

The passing of the `version` has the effect of setting `setParentNodes` to a truthy value - the effect of which is described [here](https://github.com/Microsoft/TypeScript/blob/v1.8.10/src/compiler/parser.ts#L635-L658). This might not be a problem, but it effects some less-than-useful logging, as the `version` is undefined.

@basarat, I'm am still looking into what is causing the TypeScript 2.0.0 beta to break my builds. This is just something that I noticed along the way.