### PR TITLE
Reused currently parsed source files

### DIFF
--- a/lib/Host.js
+++ b/lib/Host.js
@@ -47,17 +47,22 @@ module.exports = function (ts) {
 		}
 
 		var file;
+		var current = this.files[normalized];
 		var previous = this.previousFiles[normalized];
 		var version;
 
-		if (previous && previous.contents === text) {
+		if (current && current.contents === text) {
+			file = current.ts;
+			version = current.version;
+			log('Reused current file %s (version %d)', normalized, version);
+		} else if (previous && previous.contents === text) {
 			file = previous.ts;
 			version = previous.version;
-			log('Reused file %s (version %s)', normalized, version);
+			log('Reused previous file %s (version %d)', normalized, version);
 		} else {
 			file = ts.createSourceFile(filename, text, this.languageVersion, true);
 			version = this.version;
-			log('New version of source file %s (version %s)', normalized, version);
+			log('New version of source file %s (version %d)', normalized, version);
 		}
 
 		this.files[normalized] = {


### PR DESCRIPTION
@basarat Another small change that I made, yesterday.

When Browserify resets, the Host [keeps a copy](https://github.com/TypeStrong/tsify/blob/master/lib/Host.js#L24-L32) of the previously cached source files and checks that cache to reuse unchanged files that are added to the Host. Note that Tsify adds files from the `tsconfig.json` parse and from the Browserify entry points. This means the same file can be parsed twice - even without a reset having occurred - depending upon the `tsconfig.json`. This PR tweaks the `_addFile` implementation to check for currently parsed source files as well as previously parsed source files.

Prior to my investigation of the TypeScript 2.0.0 beta problem, I used a single `tsconfig.json` for the Sublime Text TypeScript plugin and for Tsify, which resulted in many source files being parsed twice. I've since changed this so that my Tsify-specific `tsconfig.json` includes only the `typings/index.d.ts` file. However, I think this PR's change is still worth making.

At some stage, I'll add some notes to the documentation regarding `tsconfig.json` files and what needs to be in them and what Tsify does with them. I note that there are some questions in the issues relating to that sort of thing. I'll answer those, at some stage, too.