### PR TITLE
Documented the project option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ For use on the command line, use the flag `npm install -g`.
 	* `--typescript` - This allows you to pass in a different TypeScript compiler, such as [NTypeScript](https://github.com/TypeStrong/ntypescript).  Note that when using the API, you can pass either the name of the alternative compiler or a reference to it:
 		* `{ typescript: 'ntypescript' }`
 		* `{ typescript: require('typescript') }`, useful for when you want to use a different version of the official TypeScript compiler than the one packaged with tsify.
+	* `--project` - This allows you to specify the path that will be used when searching for the `tsconfig.json` file. You can pass either the path to a directory or to the `tsconfig.json` file itself.
 
 # Does this work with...
 


### PR DESCRIPTION
@basarat Added a note to the `README.md`. It seems the `project` option was not documented. My builds now depend upon it and it seems that the option is [useful to others](https://github.com/TypeStrong/tsify/issues/168), too. The option was added in 0.15.1 ([`d461cfc`](https://github.com/TypeStrong/tsify/commit/d461cfcef3e936ebe97c5a95568ac460a39aa915)).