### PR TITLE
Added typescript@next work-around for node_modules

### DIFF
--- a/lib/Host.js
+++ b/lib/Host.js
@@ -8,6 +8,7 @@ var trace     = require('util').debuglog(require('../package').name + '-trace');
 var os        = require('os');
 var path      = require('path');
 var util      = require('util');
+var semver    = require('semver');
 
 module.exports = function (ts) {
 	function Host(currentDirectory, opts) {
@@ -81,7 +82,8 @@ module.exports = function (ts) {
 			contents: text,
 			ts: file,
 			root: root,
-			version: version
+			version: version,
+			nodeModule: /\/node_modules\/(?!typescript\/)/.test(canonical)
 		};
 		this.emit('file', canonical, relative);
 
@@ -156,6 +158,34 @@ module.exports = function (ts) {
 			rootFilenames.push(filename);
 		}
 		return rootFilenames;
+	}
+
+	Host.prototype._nodeModuleFilenames = function () {
+
+		var nodeModuleFilenames = [];
+
+		for (var filename in this.files) {
+			if (!Object.hasOwnProperty.call(this.files, filename)) continue;
+			if (!this.files[filename].nodeModule) continue;
+			nodeModuleFilenames.push(filename);
+		}
+		return nodeModuleFilenames;
+	}
+
+	Host.prototype._compile = function (opts) {
+
+		var rootFilenames = this._rootFilenames();
+		var nodeModuleFilenames = [];
+
+		log('Compiling files:');
+		rootFilenames.forEach(function (file) { log('  %s', file); });
+
+		if (semver.gte(ts.version, '2.0.0')) {
+			ts.createProgram(rootFilenames, opts, this);
+			nodeModuleFilenames = this._nodeModuleFilenames();
+			log('  + %d file(s) found in node_modules', nodeModuleFilenames.length);
+		}
+		return ts.createProgram(rootFilenames.concat(nodeModuleFilenames), opts, this);
 	}
 
 	Host.prototype._output = function (filename) {

--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -155,13 +155,9 @@ module.exports = function (ts) {
 
 	Tsifier.prototype.compile = function () {
 		var self = this;
-		var rootFilenames = self.host._rootFilenames();
-
-		log('Compiling files:');
-		rootFilenames.forEach(function (file) { log('  %s', file); });
 
 		var createProgram_t0 = time.start();
-		var program = ts.createProgram(rootFilenames, self.opts, self.host);
+		var program = self.host._compile(self.opts);
 		time.stop(createProgram_t0, 'createProgram');
 
 		var syntaxDiagnostics = self.checkSyntax(program);

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   },
   "dependencies": {
     "convert-source-map": "^1.1.0",
+    "fs.realpath": "^1.0.0",
+    "semver": "^5.1.0",
     "through2": "^2.0.0",
-    "tsconfig": "^2.2.0",
-    "fs.realpath": "^1.0.0"
+    "tsconfig": "^2.2.0"
   },
   "devDependencies": {
     "babel-preset-react": "^6.5.0",
@@ -40,7 +41,6 @@
     "event-stream": "^3.3.1",
     "fs-extra": "^0.30.0",
     "node-foo": "^0.2.3",
-    "semver": "^5.1.0",
     "source-map": "^0.5.3",
     "tape": "^4.0.0",
     "test-peer-range": "^1.0.1",


### PR DESCRIPTION
Initial attempt at a work-around for `typescript@next` to avoid re-compilations for each cache miss on files in `node_modules` - see #172.