### PR TITLE
Ignore tsconfig include setting.

### DIFF
--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -80,6 +80,8 @@ module.exports = function (ts) {
 			};
 		}
 
+		delete config.include;
+
 		var parsed = parseJsonConfigFileContent(config, {
 			useCaseSensitiveFileNames: true,
 			readDirectory: ts.sys.readDirectory,


### PR DESCRIPTION
Typescript 2.0 introduces an `include` config option in `tsconfig.json` for specifying input files via glob patterns. The resulting file list makes it into tsify and is subsequently compiled :bomb: This change scrubs `include` from the config.
