### PR TITLE
Emit an error for a repeated cache miss

### DIFF
--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -279,8 +279,10 @@ module.exports = function (ts) {
 		var output = self.host._output(replaceFileExtension(inputFile, outputExtension));
 
 		if (!output) {
-			if (alreadyMissedCache)
+			if (alreadyMissedCache) {
+				self.emit('error', new Error('tsify: no compiled file for ' + inputFile));
 				return;
+			}
 			self.generateCache([inputFile]);
 			if (self.host.error)
 				return;


### PR DESCRIPTION
Otherwise, diagnosing problems is monumentally painful. For such a catastrophic situation, it doesn't make much sense to simply emit an empty module.