### PR TITLE
Used ts.sys as the ParseConfigHost

### DIFF
--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -80,11 +80,13 @@ module.exports = function (ts) {
 			};
 		}
 
-		var parsed = parseJsonConfigFileContent(config, {
-			useCaseSensitiveFileNames: true,
-			readDirectory: ts.sys.readDirectory,
-			fileExists: ts.sys.fileExists
-		}, '');
+		var parsed = parseJsonConfigFileContent(
+			config,
+			ts.sys,
+			configFile ? path.dirname(configFile) : currentDirectory,
+			null,
+			configFile
+		);
 
 		// Generate inline sourcemaps if Browserify's --debug option is set
 		parsed.options.sourceMap = false;


### PR DESCRIPTION
As per [this](https://github.com/alm-tools/alm/blob/ca90b703424e18390b0756784f05c2ea4c1a5702/src/server/workers/lang/core/tsconfig.ts#L262) example.