### PR TITLE
Called normalizeSlashes in getDefaultLibFileName

### DIFF
--- a/lib/Host.js
+++ b/lib/Host.js
@@ -104,7 +104,7 @@ module.exports = function (ts) {
 	Host.prototype.getDefaultLibFileName = function () {
 		var libPath = path.dirname(ts.sys.getExecutingFilePath());
 		var libFile = ts.getDefaultLibFileName({ target: this.languageVersion });
-		return path.join(libPath, libFile);
+		return ts.normalizeSlashes(path.join(libPath, libFile));
 	};
 
 	Host.prototype.writeFile = function (filename, data) {


### PR DESCRIPTION
Without this TypeScript 2 breaks when trying to determine the location of the `lib` directory on Windows.