### PR TITLE
Check real fs case sensitivity

### DIFF
--- a/lib/Host.js
+++ b/lib/Host.js
@@ -130,7 +130,7 @@ module.exports = function (ts) {
 	};
 
 	Host.prototype.getCanonicalFileName = function (filename) {
-		return ts.normalizeSlashes(ts.sys.useCaseSensitiveFileNames ? filename : filename.toLowerCase());
+		return ts.normalizeSlashes(this.useCaseSensitiveFileNames() ? filename : filename.toLowerCase());
 	};
 
 	Host.prototype.useCaseSensitiveFileNames = function () {

--- a/lib/Host.js
+++ b/lib/Host.js
@@ -1,14 +1,16 @@
 'use strict';
 
-var events    = require('events');
-var fs        = require('fs');
-var realpath  = require('fs.realpath');
-var log       = require('util').debuglog(require('../package').name);
-var trace     = require('util').debuglog(require('../package').name + '-trace');
-var os        = require('os');
-var path      = require('path');
-var util      = require('util');
-var semver    = require('semver');
+var events         = require('events');
+var fs             = require('fs');
+var realpath       = require('fs.realpath');
+var log            = require('util').debuglog(require('../package').name);
+var trace          = require('util').debuglog(require('../package').name + '-trace');
+var os             = require('os');
+var path           = require('path');
+var util           = require('util');
+var semver         = require('semver');
+var isFsSensitive  = require('fs-file-name-sensitive');
+
 
 module.exports = function (ts) {
 	function Host(currentDirectory, opts) {
@@ -132,8 +134,8 @@ module.exports = function (ts) {
 	};
 
 	Host.prototype.useCaseSensitiveFileNames = function () {
-		var platform = os.platform();
-		return platform !== 'win32' && platform !== 'win64' && platform !== 'darwin';
+		//Check case sensitivity based on real fs behavior.
+		return isFsSensitive(__dirname);
 	};
 
 	Host.prototype.getNewLine = function () {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "convert-source-map": "^1.1.0",
+    "fs-file-name-sensitive": "^0.1.2",
     "fs.realpath": "^1.0.0",
     "object-assign": "^4.1.0",
     "semver": "^5.1.0",


### PR DESCRIPTION
Fix for #200 

I used [fs-file-name-sensitive](https://github.com/snowyu/fs-file-name-sensitive.js) module to check the case sensitivity on some file (`__filename` in Host.js). It simply checks, if we change filename to upper case, would it be opened.

The solution is not so elegant, but works fine for me.