### PR TITLE
Bugfix case-sensitive resolve

### DIFF
--- a/lib/Host.js
+++ b/lib/Host.js
@@ -49,12 +49,14 @@ module.exports = function (ts) {
 		// to 'createSourceFile', as that's the name that will be used in error
 		// messages, etc.
 
+		var resolved = path.resolve(
+			this.currentDirectory,
+			filename
+		);
+
 		var relative = ts.normalizeSlashes(path.relative(
 			this.currentDirectory,
-			path.resolve(
-				this.currentDirectory,
-				filename
-			)
+			this.caseSensitive ? resolved : resolved.toLowerCase()
 		));
 		var canonical = this._canonical(filename);
 		trace('Parsing %s', canonical);

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,15 @@ var tsify = require('..');
 
 var buildTimeout = 8000;
 
+var caseSensitive;
+
+try {
+	fs.accessSync(path.join(__dirname, path.basename(__filename).toUpperCase()), fs.constants.R_OK);
+	caseSensitive = false;
+} catch (error) {
+	caseSensitive = true;
+}
+
 // Tests
 
 test('host', function (t) {
@@ -296,9 +305,14 @@ test('syntax error', function (t) {
 	run({
 		bOpts: { entries: ['./test/syntaxError/x.ts'] }
 	}, function (errors, actual) {
+		var fileName = (caseSensitive) 
+			? 'test/syntaxError/x.ts' 
+			: 'test/syntaxerror/x.ts'
+		;
+
 		expectErrors(t, errors, [
-			{ name: 'TS1005', line: 1, column: 9, file: 'test/syntaxError/x.ts' },
-			{ name: 'TS1005', line: 2, column: 9, file: 'test/syntaxError/x.ts' }
+			{ name: 'TS1005', line: 1, column: 9, file: fileName },
+			{ name: 'TS1005', line: 2, column: 9, file: fileName }
 		]);
 		expectNoOutput(t, actual);
 		t.end();
@@ -309,8 +323,13 @@ test('type error', function (t) {
 	run({
 		bOpts: { entries: ['./test/typeError/x.ts'] }
 	}, function (errors, actual) {
+		var fileName = (caseSensitive) 
+			? 'test/typeError/x.ts' 
+			: 'test/typeerror/x.ts'
+		;
+
 		expectErrors(t, errors, [
-			{ name: 'TS2345', line: 4, column: 3, file: 'test/typeError/x.ts' }
+			{ name: 'TS2345', line: 4, column: 3, file: fileName }
 		]);
 		expectConsoleOutputFromScript(t, actual, [
 			'hello world',
@@ -328,8 +347,13 @@ test('type error with noEmitOnError', function (t) {
 		bOpts: { entries: ['./test/typeError/x.ts'] },
 		tsifyOpts: { noEmitOnError: true }
 	}, function (errors, actual) {
+		var fileName = (caseSensitive) 
+			? 'test/typeError/x.ts' 
+			: 'test/typeerror/x.ts'
+		;
+
 		expectErrors(t, errors, [
-			{ name: 'TS2345', line: 4, column: 3, file: 'test/typeError/x.ts' }
+			{ name: 'TS2345', line: 4, column: 3, file: fileName }
 		]);
 		expectNoOutput(t, actual);
 		t.end();


### PR DESCRIPTION
I noticed that the check for case-sensitivity in `Host.js` as shown below:

```javascript
function Host(currentDirectory, opts) {

  try {
    fs.accessSync(path.join(__dirname, path.basename(__filename).toUpperCase()), fs.constants.R_OK);
    this.caseSensitive = false;
  } catch (error) {
    this.caseSensitive = true;
  }

  this.currentDirectory = this.getCanonicalFileName(path.resolve(currentDirectory));
  this.outputDirectory = this.getCanonicalFileName(path.resolve(opts.outDir));
  this.rootDirectory = this.getCanonicalFileName(path.resolve(opts.rootDir));
  this.languageVersion = opts.target;
  this.files = {};
  this.previousFiles = {};
  this.output = {};
  this.version = 0;
  this.error = false;
}
```

Was taking my `currentDirectory` which was: `"/Users/ajmchambers/Documents/create-cycle-app/typescript-test"`. 

Then storing it as lowercase in `this.currentDirectory` as `"/users/ajmchambers/documents/create-cycle-app/typescript-test"`.

Later on in `Host.prototype._addFile` it does this:

```javascript
Host.prototype._addFile = function (filename, root) {

  // Ensure that the relative, non-canonical file name is what's passed
  // to 'createSourceFile', as that's the name that will be used in error
  // messages, etc.

  var relative = ts.normalizeSlashes(path.relative(
    this.currentDirectory,
    path.resolve(
      this.currentDirectory,
      filename
    )
  ));
  var canonical = this._canonical(filename);
  trace('Parsing %s', canonical);

  // ...
```

The `path.resolve(this.currentDirectory, filename)` returns:

`"/Users/ajmchambers/Documents/create-cycle-app/typescript-test/src/index.ts"`

Which then when combined with `path.relative(this.currentDirectory, ... )` returns:

`"../../../../../Users/ajmchambers/Documents/create-cycle-app/typescript-test/src/index.ts"`

So I changed the above to:

```javascript
Host.prototype._addFile = function (filename, root) {

  // Ensure that the relative, non-canonical file name is what's passed
  // to 'createSourceFile', as that's the name that will be used in error
  // messages, etc.

  var resolved = path.resolve(
    this.currentDirectory,
    filename
  );

  var relative = ts.normalizeSlashes(path.relative(
    this.currentDirectory,
    this.caseSensitive ? resolved : resolved.toLowerCase()
  ));
  var canonical = this._canonical(filename);
  trace('Parsing %s', canonical);

  // ...
```

Now `path.relative` returns `"src/index.ts"`. 

This change broke a few tests that were expecting a result string that was case-sensitive, so I modified `tests.js` to take this into account.

At the top of the file I added the case-sensitive check:

```javascript
var caseSensitive;

try {
	fs.accessSync(path.join(__dirname, path.basename(__filename).toUpperCase()), fs.constants.R_OK);
	caseSensitive = false;
} catch (error) {
	caseSensitive = true;
}
```  

Then in the failing tests I did this:

```javascript
test('syntax error', function (t) {
	run({
		bOpts: { entries: ['./test/syntaxError/x.ts'] }
	}, function (errors, actual) {
		var fileName = (caseSensitive) 
			? 'test/syntaxError/x.ts' 
			: 'test/syntaxerror/x.ts'
		;

		expectErrors(t, errors, [
			{ name: 'TS1005', line: 1, column: 9, file: fileName },
			{ name: 'TS1005', line: 2, column: 9, file: fileName }
		]);
		expectNoOutput(t, actual);
		t.end();
	});
});
```

Let me know what you think.

Cheers