### PR TITLE
Explicitly use browserify entries

### DIFF
--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -87,6 +87,12 @@ module.exports = function (ts) {
 				};
 			}
 		}
+		if (bopts.entries) {
+			extend(config, {
+				files: bopts.entries,
+				includes: []
+			});
+		}
 
 		var parsed = parseJsonConfigFileContent(
 			config,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsify",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Browserify plugin for compiling Typescript",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
And again, saga about **includes**, in addition to https://github.com/TypeStrong/tsify/pull/183 and https://github.com/TypeStrong/tsify/issues/147.

My proposition is to explicitly specify list of files to compile based on browserify entries list.
It looks redundant to compile all files according to tsconfig.

If we have several bundles, now we can get errors unrelated to compiled bundle, if they are.
If we try to compile several bundles in one run, like I do in gulp with 
```
gulp.task("default", ["build-deps", "build"]);
```
It will compile all files twice, that is sensitive performance drawback.