### PR TITLE
Adds support for baseUrl when transforming imports

### DIFF
--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -21,6 +21,8 @@ module.exports = function (ts) {
 
 	var parseJsonConfigFileContent = ts.parseJsonConfigFileContent || ts.parseConfigFile;
 
+	var requireMatcher = new RegExp("require\\(([\"'])([^./])", "g");
+
 	function isTypescript(file) {
 		return (/\.tsx?$/i).test(file);
 	}
@@ -302,6 +304,11 @@ module.exports = function (ts) {
 			if (self.host.error)
 				return;
 			return self.getCompiledFile(inputFile, true);
+		}
+
+		if (self.opts.baseUrl) {
+			relativePrefix = "../".repeat(inputFile.substr(self.opts.baseUrl.length + 1).split("/").length - 1);
+			output = output.replace(requireMatcher, "require($1" + relativePrefix + "$2");
 		}
 
 		if (self.opts.inlineSourceMap) {


### PR DESCRIPTION
This addresses part of issue #160, but only adds support for `baseUrl`. `paths` and `rootDirs` are still not considered.