### PR TITLE
Support forceConsistentCasingInFilenames flag

### DIFF
--- a/lib/Host.js
+++ b/lib/Host.js
@@ -12,19 +12,19 @@ var semver    = require('semver');
 
 module.exports = function (ts) {
 
-	var caseSensitive;
+	var isCaseSensitiveFileSystem;
 
 	try {
 		fs.accessSync(path.join(__dirname, path.basename(__filename).toUpperCase()), fs.constants.R_OK);
-		caseSensitive = false;
+		isCaseSensitiveFileSystem = false;
 	} catch (error) {
 		trace('Case sensitive detection error: %s', error);
-		caseSensitive = true;
+		isCaseSensitiveFileSystem = true;
 	}
-	log('Detected case %s file system', caseSensitive ? 'sensitive' : 'insensitive');
+	log('Detected case %s file system', isCaseSensitiveFileSystem ? 'sensitive' : 'insensitive');
 
 	function Host(currentDirectory, opts) {
-
+		this.isCaseSensitive = !!opts.forceConsistentCasingInFileNames || isCaseSensitiveFileSystem;
 		this.currentDirectory = this.getCanonicalFileName(path.resolve(currentDirectory));
 		this.outputDirectory = this.getCanonicalFileName(path.resolve(opts.outDir));
 		this.rootDirectory = this.getCanonicalFileName(path.resolve(opts.rootDir));
@@ -138,13 +138,13 @@ module.exports = function (ts) {
 	};
 
 	Host.getCanonicalFileName = function (filename) {
-		return ts.normalizeSlashes(caseSensitive ? filename : filename.toLowerCase());
+		return ts.normalizeSlashes(this.isCaseSensitive || isCaseSensitiveFileSystem ? filename : filename.toLowerCase());
 	};
 
 	Host.prototype.getCanonicalFileName = Host.getCanonicalFileName;
 
 	Host.useCaseSensitiveFileNames = function () {
-		return caseSensitive;
+		return this.isCaseSensitive || isCaseSensitiveFileSystem;
 	};
 
 	Host.prototype.useCaseSensitiveFileNames = Host.useCaseSensitiveFileNames;


### PR DESCRIPTION
If enabled ignore the case sensitivity of the
underlying filesystem, and expect fileanmes
to be case sensitive.

I don't think it is possible to add a CI test
for this, as travis runs on a case sensitive
filesystem.