### PR TITLE
fix Host.prototype._addFile read relative file path error

### DIFF
--- a/lib/Host.js
+++ b/lib/Host.js
@@ -63,7 +63,7 @@ module.exports = function (ts) {
 
 		var text;
 		try {
-			text = fs.readFileSync(filename, 'utf-8');
+			text = fs.readFileSync(canonical, 'utf-8');
 		} catch (ex) {
 			return;
 		}


### PR DESCRIPTION
use canonical path for reading file. if cwd is not project workspace, relative filename will cast read error.