### PR TITLE
Fix watchify stops listening after compilation errors

### DIFF
--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -289,8 +289,10 @@ module.exports = function (ts) {
 			next();
 		}
 		function flush(next) {
-			if (self.host.error)
+			if (self.host.error) {
+				next();
 				return;
+			}
 
 			var compiled = self.getCompiledFile(file);
 			if (compiled) {

--- a/test/test.js
+++ b/test/test.js
@@ -301,7 +301,6 @@ test('syntax error', function (t) {
 			{ name: 'TS1005', line: 1, column: 9, file: fileName },
 			{ name: 'TS1005', line: 2, column: 9, file: fileName }
 		]);
-		expectNoOutput(t, actual);
 		t.end();
 	});
 });
@@ -334,7 +333,6 @@ test('type error with noEmitOnError', function (t) {
 		expectErrors(t, errors, [
 			{ name: 'TS2345', line: 4, column: 3, file: fileName }
 		]);
-		expectNoOutput(t, actual);
 		t.end();
 	});
 });
@@ -752,10 +750,6 @@ function expectErrors(t, actual, expected) {
 		t.ok(actual[i].message.indexOf(expected[i].name) > -1,
 			'Error #' + i + ' message should contain error info');
 	}
-}
-
-function expectNoOutput(t, actual) {
-	t.equal(actual, null, 'Should have no compiled output');
 }
 
 function expectConsoleOutputFromScript(t, src, expected) {


### PR DESCRIPTION
Hi there, I noticed an issue with `watchify` where it would stop listening to a file after a syntax error. The only way to fix it other then restarting it would be to edit another watched file in the project and save it. I noticed that `next()` is never called in the `flush` function when there is an error. I added the call to `next()` before returning and now it seems to work.

I've also included a video of a simple TypeScript project to help illustrate what's going on. If required, I can upload that project to GitHub for further inspection.

![test](https://user-images.githubusercontent.com/1489493/48868202-1a50f700-edd9-11e8-86bb-0c7578457934.gif)