### PR TITLE
Add TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,15 @@
+import { BrowserifyObject, CustomOptions } from "browserify";
+import { CompilerOptions, ModuleKind, ScriptTarget } from "typescript";
+
+export interface Options extends CustomOptions, CompilerOptions {
+	typescript?: string | import("typescript");
+	global?: boolean;
+	m?: ts.ModuleKind;
+	p?: string | ts.CompilerOptions;
+	project?: string | ts.CompilerOptions;
+	t?: ts.ScriptTarget;
+}
+
+function tsify(b: BrowserifyObject, opts: Options): any;
+
+export = tsify;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,10 +4,10 @@ import { CompilerOptions, ModuleKind, ScriptTarget } from "typescript";
 export interface Options extends CustomOptions, CompilerOptions {
 	typescript?: string | import("typescript");
 	global?: boolean;
-	m?: ts.ModuleKind;
-	p?: string | ts.CompilerOptions;
-	project?: string | ts.CompilerOptions;
-	t?: ts.ScriptTarget;
+	m?: ModuleKind;
+	p?: string | CompilerOptions;
+	project?: string | CompilerOptions;
+	t?: ScriptTarget;
 }
 
 function tsify(b: BrowserifyObject, opts: Options): any;


### PR DESCRIPTION
This adds TypeScript types so the `tsify` package can be imported from `TypeScript` files without throwing errors. Please note that the `Options` interface might be incomplete.