### PR TITLE
Fix types in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,11 @@
 import { BrowserifyObject, CustomOptions } from "browserify";
-import { CompilerOptions, ModuleKind, ScriptTarget } from "typescript";
+import typescript, { CompilerOptions, ModuleKind, ScriptTarget } from "typescript";
 
-export interface Options extends CustomOptions, CompilerOptions {
-	typescript?: string | import("typescript");
+// Provide local definition of Omit for compatibility with TypeScript <3.5
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+
+export interface Options extends CustomOptions, Omit<CompilerOptions, "project"> {
+	typescript?: string | typeof typescript;
 	global?: boolean;
 	m?: ModuleKind;
 	p?: string | CompilerOptions;
@@ -10,6 +13,4 @@ export interface Options extends CustomOptions, CompilerOptions {
 	t?: ScriptTarget;
 }
 
-function tsify(b: BrowserifyObject, opts: Options): any;
-
-export = tsify;
+export default function tsify(b: BrowserifyObject, opts: Options): any;


### PR DESCRIPTION
In the current version of (4.0.2) importing `tsify` in a TypeScript project causes the following compilation error:

```
node_modules/tsify/index.d.ts:4:18 - error TS2430: Interface 'Options' incorrectly extends interface 'CompilerOptions'.
  Types of property 'project' are incompatible.
    Type 'string | CompilerOptions | undefined' is not assignable to type 'string | undefined'.
      Type 'CompilerOptions' is not assignable to type 'string'.

   export interface Options extends CustomOptions, CompilerOptions {
                    ~~~~~~~

node_modules/tsify/index.d.ts:5:24 - error TS1340: Module 'typescript' does not refer to a type, but is used as a type here. Did you mean 'typeof import('typescript')'?

   typescript?: string | import("typescript");
                         ~~~~~~~~~~~~~~~~~~~~

node_modules/tsify/index.d.ts:13:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

   function tsify(b: BrowserifyObject, opts: Options): any;
   ~~~~~~~~

node_modules/tsify/index.d.ts:15:1 - error TS2309: An export assignment cannot be used in a module with other exported elements.

   export = tsify;
   ~~~~~~~~~~~~~~~


Found 4 errors.
```

This change fixes those errors in a way that maintains compatibility with TypeScript >= 2.8.

## Testing

I'm not sure how best to include automated tests for this change in this repository. You can review my manual testing strategy at [brianloveswords/tsify-repro-types-issue](https://github.com/brianloveswords/tsify-repro-types-issue).