### PR TITLE
Improve check for case sensitivity of filesystem

### DIFF
--- a/lib/Host.js
+++ b/lib/Host.js
@@ -15,7 +15,7 @@ module.exports = function (ts) {
 	var isCaseSensitiveFileSystem;
 
 	try {
-		fs.accessSync(path.join(__dirname, path.basename(__filename).toUpperCase()), fs.constants.R_OK);
+		fs.accessSync(path.join(__dirname, path.basename(__filename)).toUpperCase(), fs.constants.R_OK);
 		isCaseSensitiveFileSystem = false;
 	} catch (error) {
 		trace('Case sensitive detection error: %s', error);


### PR DESCRIPTION
Fixes #277.

This patch is better at detecting filesystem setups that are only partly case sensitive. It will remove the "feature" of case insensitive behavior if any part of the path is case sensitive (which I personally don't miss at all).

Please note that the approach used to check for case sensitivity breaks if the part of the path that is case sensitive is already uppercase (probably an uncommon edge case though). Doing the same check additionally with `toLowerCase()` would fix that, not sure whether it's worth it.