### PR TITLE
Fix broken type-declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,4 +15,5 @@ export interface Options {
 	typescript?: string | typeof typescript;
 }
 
-export default function tsify(b: any, opts: Options): any;
+declare function tsify(b: any, opts: Options): any;
+export = tsify;


### PR DESCRIPTION
The current type-declaration `export default function tsify(...)` suggests that a default export is present in the corresponding javascript.
But `tsify` doesn't actually use a `module.exports.default = function tsify(...)` or `export default function tsify(...)` as seen here:
https://github.com/TypeStrong/tsify/blob/437e5b51fce8dfc3c92c218ee66633dc71a7d3ef/index.js#L96

For that reason, this module currently can't be consumed correctly using typescript.

This PR fixes the described issue.