### PR TITLE
Fix error [DEP0060] in Tsifier.js

### DIFF
--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -2,7 +2,7 @@
 
 var convert  = require('convert-source-map');
 var events   = require('events');
-var extend   = require('util')._extend;
+var extend   = Object.assign;
 var fs       = require('fs');
 var realpath = require('fs.realpath');
 var log      = require('util').debuglog(require('../package').name);


### PR DESCRIPTION
# Fix Error [DEP0060]

- Error : 

   (node:12920) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead. (Use `node --trace-deprecation ...` to show where the warning was created)

> Fixed by replacing the `require('util')._extend` with `Object.assign`